### PR TITLE
Correct example code: fn discountedAndTaxedPrice

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,10 +70,12 @@ add a tax percentage to be added to the sales price? We'll honor best
 pratices and put `tax` before `discount`.
 
 ```js
-function discountedAndTaxedPrice(itemPrice, tax, discount = 0.25){
-    return itemPrice - (itemPrice * discount) + (itemPrice * tax)
-}
-discountedAndTaxedPrice(100, 0.15) //=> 90
+function discountedAndTaxedPrice(itemPrice, tax, discount = 0.25) {
+  let subtotal = itemPrice - (itemPrice * discount);
+  return subtotal + (subtotal * tax);
+};
+
+discountedAndTaxedPrice(100, 0.15); //=> 86.25
 ```
 
 


### PR DESCRIPTION
Fixes #11 

The current code is calculating the tax based on the item's original price when it should be calculating the tax based on the item's discounted price.

An alternative example could be:

```js
function discountedAndTaxedPrice(itemPrice, tax, discount = 0.25) {
  let subtotal = itemPrice * (1 - discount);
  return subtotal * (1 + tax);
};

discountedAndTaxedPrice(100, 0.15); //=> 86.25
```